### PR TITLE
Prettier referenciado de maneira simples e regras eslint adicionadas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     node: true,
     jest: true,
   },
-  extends: ['plugin:react/recommended', 'airbnb', 'prettier/react', 'prettier/javascript'],
+  extends: ['plugin:react/recommended', 'airbnb', 'prettier'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
@@ -16,5 +16,8 @@ module.exports = {
   plugins: ['react', 'prettier'],
   rules: {
     'prettier/prettier': 'error',
+    'react/jsx-filename-extension': 'off',
+    'react/react-in-jsx-scope': 'off',
+    'import/no-unresolved': 'off',
   },
 };


### PR DESCRIPTION
#### Qual o objetivo dessa Pull Request?

Atualizar arquivo de configuração do Eslint.

#### Que problema está resolvendo?

Permite que o arquivo de configuração do Eslint seja atualizado e a nova referência ao Prettier seja consertada. Anteriormente, esse plugin deveria ser referenciado com cada um de seus plugins, ou seja, prettier/react, prettier/javascript. Porém, agora devemos referenciar a todos como 'prettier'.
Vide changelog: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
